### PR TITLE
Point support forum link to qbittorrent instead of rtorrent thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ If you appreciate my work, then please consider buying me a beer  :D
 
 [![PayPal donation](https://www.paypal.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MM5E27UX6AUU4)
 
-[Support forum](http://lime-technology.com/forum/index.php?topic=47832.0)
+[Support forum](https://forums.unraid.net/topic/75539-support-binhex-qbittorrentvpn/)


### PR DESCRIPTION
The support link goes to the rtorrent thread, point it at the qbittorrent thread instead!

Thanks a bunch for making a qB + vpn image, took me long enough to notice it! :)