### PR TITLE
Setup CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,16 @@
+# Docker image
+# Build a Docker image to deploy, run, or push to a container registry.
+# Add steps that use Docker Compose, tag images, push to a registry, run an image, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/docker
+
+trigger:
+- master
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- script: |
+    docker build -t "$(dockerId)/$(imageName)" .
+    docker login -u "$(dockerId)" -p "$(pswd)"
+    docker push "$(dockerId)/$(imageName)"


### PR DESCRIPTION
I've noticed the docker image for this on docker hub is fairly old. Considering Arch is a very fast-moving distro it would be nice if the image was updated more often.

I've created an Azure Pipelines configuration you could use to set-up CI and automatically push the image to docker hub.
Azure Pipelines can be set-up (WebUI only for now) to rerun CI at an interval so you could use this to update image weekly to ensure it stays up-to-date.

You'd need to set all the variables (`dockerID`, `pswd` and `imageName`) in the web-interface. `pswd` should be a set as a secret variable. `dockerID` and `imageName` could also be replaced with hardcoded values.