### PR TITLE
add support for randomly chosen *.ovpn files

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -157,7 +157,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	rm -f /tmp/checkiptables || true
 
 	# wildcard search for openvpn config files (match on first result)
-	export VPN_CONFIG=$(find /config/openvpn -maxdepth 1 -name "*.ovpn" -print -quit)
+	export VPN_CONFIG=$(find /config/openvpn -maxdepth 1 -name "*.ovpn" -print | shuf -n1)
 
 	# if ovpn file not found in /config/openvpn then exit
 	if [[ -z "${VPN_CONFIG}" ]]; then


### PR DESCRIPTION
Add ability to have docker container randomly choose from multiple .ovpn files located in /config/openvpn. This is good for moving your location from time to good to provide a better sense of protection while behind a VPN. As well, server are known to become saturated at times, so a potential restart of your container would solve this issue by rotating you to another.

This is a simple/graceful solution to implement server rotation without attempting to support "remote-random" which is integrated into openvpn, however would require a larger rework of the existing scripting logic, which is unnecessary.

To use, include multiple *.ovpn files from your current VPN provider into the /config/openvpn folder. On container restart, one of the *.ovpn files will be randomly chosen for use, using the credentials stored in your docker template.

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>