### PR TITLE
Update install.sh

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -31,7 +31,7 @@ TARGETARCH="${2}"
 source upd.sh
 
 # define pacman packages
-pacman_packages="qbittorrent-nox python geoip"
+pacman_packages="qbittorrent-nox python geoip ldns"
 
 # install compiled packages using pacman
 if [[ ! -z "${pacman_packages}" ]]; then


### PR DESCRIPTION
Added ldns to the pacman_packages because the drill command is missing from the container without it.

This solves https://github.com/binhex/arch-qbittorrentvpn/issues/230