### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ Alternatively, you can configure it via the filesystem located at `/config/qbitt
 session\Port=49400
 ```
 
-## **IMPORTANT** 
+## IMPORTANT Note On VPN_INPUT_PORTS!
+
 Please note 'VPN_INPUT_PORTS' is **NOT** to define the incoming port for the VPN, this environment variable is used to define port(s) you want to allow into the VPN network when network binding multiple containers together, configuring this incorrectly with the VPN provider assigned incoming port COULD result in IP leakage, you have been warned!.
 
 ## OpenVPN

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-**Application**
+# **Application**
 
 [qBittorrent](https://www.qbittorrent.org/)<br/>
 [Privoxy](http://www.privoxy.org/)<br/>
 [OpenVPN](https://openvpn.net/)<br/>
 [WireGuard](https://www.wireguard.com/)
 
-**Description**
+# **Description**
 
-qBittorrent is a bittorrent client programmed in C++ / Qt that uses libtorrent (sometimes called libtorrent-rasterbar) by Arvid Norberg. It aims to be a good alternative to all other bittorrent clients out there. qBittorrent is fast, stable and provides unicode support as well as many features.<br/>
+qBittorrent is a BitTorrent client programmed in C++ / Qt that uses libtorrent (sometimes called libtorrent-rasterbar) by Arvid Norberg. It aims to be a good alternative to all other BitTorrent clients out there. qBittorrent is fast, stable and provides unicode support as well as many features.
 
-This Docker includes OpenVPN and WireGuard to ensure a secure and private connection to the Internet, including use of iptables to prevent IP leakage when the tunnel is down. It also includes Privoxy to allow unfiltered access to index sites, to use Privoxy please point your application at `http://<host ip>:8118`.
+This Docker includes OpenVPN and WireGuard to ensure a secure and private connection to the Internet, including the use of iptables to prevent IP leakage when the tunnel is down. It also includes Privoxy to allow unfiltered access to index sites, to use Privoxy please point your application at `http://<host ip>:8118`.
 
-**Build notes**
+# **Build notes**
 
 Latest stable qBittorrent release from Arch Linux repo.<br/>
 Latest stable Privoxy release from Arch Linux repo.<br/>
 Latest stable OpenVPN release from Arch Linux repo.<br/>
 Latest stable WireGuard release from Arch Linux repo.
 
-**Usage**
+## **Usage**
 ```
 docker run -d \
     --cap-add=NET_ADMIN \
@@ -50,21 +50,21 @@ docker run -d \
     -e PGID=<gid for user> \
     binhex/arch-qbittorrentvpn
 ```
-&nbsp;
+
 Please replace all user variables in the above command defined by <> with the correct values.
 
-**Access qBittorrent (web ui)**
+## **Access qBittorrent (web ui)**
 
 `http://<host ip>:8080/`
 
 Username:- `admin`<br>
 Password:- randomly generated, password shown in `/config/supervisord.log`
 
-**Access Privoxy**
+## **Access Privoxy**
 
 `http://<host ip>:8118`
 
-**PIA example**
+## **PIA example**
 ```
 docker run -d \
     --cap-add=NET_ADMIN \
@@ -95,27 +95,36 @@ docker run -d \
     -e PGID=0 \
     binhex/arch-qbittorrentvpn
 ```
-&nbsp;
-**AirVPN provider**
+
+## **AirVPN provider**
 
 AirVPN users will need to generate a unique OpenVPN configuration file by using the following link https://airvpn.org/generator/
 
 1. Please select Linux and then choose the country you want to connect to
 2. Save the ovpn file to somewhere safe
-3. Start the qbittorrentvpn docker to create the folder structure
-4. Stop qbittorrentvpn docker and copy the saved ovpn file to the /config/openvpn/ folder on the host
-5. Start qbittorrentvpn docker
+3. Start the QBitTorrentVPN docker to create the folder structure
+4. Stop QBitTorrentVPN docker and copy the saved ovpn file to the /config/openvpn/ folder on the host
+5. Start QBitTorrentVPN docker
 6. Check supervisor.log to make sure you are connected to the tunnel
 
-AirVPN users will also need to create a port forward by using the following link https://airvpn.org/ports/ and clicking Add. This port will need to be specified in the qBittorrent configuration file located at /config/qbittorrent/config/qbittorrent.conf.
+### Port Forwarding
+AirVPN users will also need to create a port forward by using the following link https://airvpn.org/ports/ and clicking Add. This port will need to be specified in qBittorrent. Generally, it is better practice to use the WebUI to configure this port under: 
+`Tools->Options->Connection`
 
-qBittorrent example config
+![image](https://github.com/binhex/arch-QBitTorrentVPN/assets/872224/bcad7fc2-94a2-464a-8e3a-7fa3eae9a3c7)
+
+Then enter the port.
+
+![image](https://github.com/binhex/arch-QBitTorrentVPN/assets/872224/f83e7395-1da0-4fc3-841f-f185ea6d6798)
+
+Alternatively, you can configure it via the filesystem located at `/config/qbittorrent/config/qbittorrent.conf`.
+
+### Example qBittorrent.conf
 ```
-port_range = 49400-49400
-port_random = no
+session\Port=49400
 ```
-&nbsp;
-**AirVPN example**
+
+### **AirVPN example**
 ```
 docker run -d \
     --cap-add=NET_ADMIN \
@@ -123,7 +132,7 @@ docker run -d \
     -p 6881:6881/udp \
     -p 8080:8080 \
     -p 8118:8118 \
-    --name=qbittorrentvpn \
+    --name=qbitTorrentvpn \
     -v /root/docker/data:/data \
     -v /root/docker/config:/config \
     -v /etc/localtime:/etc/localtime:ro \
@@ -143,13 +152,13 @@ docker run -d \
     -e PGID=0 \
     binhex/arch-qbittorrentvpn
 ```
-&nbsp;
 
-**IMPORTANT**<br/>
-Please note 'VPN_INPUT_PORTS' is **NOT** to define the incoming port for the VPN, this environment variable is used to define port(s) you want to allow in to the VPN network when network binding multiple containers together, configuring this incorrectly with the VPN provider assigned incoming port COULD result in IP leakage, you have been warned!.
 
-**OpenVPN**<br/>
-Please note this Docker image does not include the required OpenVPN configuration file and certificates. These will typically be downloaded from your VPN providers website (look for OpenVPN configuration files), and generally are zipped.
+## **IMPORTANT** 
+Please note 'VPN_INPUT_PORTS' is **NOT** to define the incoming port for the VPN, this environment variable is used to define port(s) you want to allow into the VPN network when network binding multiple containers together, configuring this incorrectly with the VPN provider assigned incoming port COULD result in IP leakage, you have been warned!.
+
+## **OpenVPN**<br/>
+Please note this Docker image does not include the required OpenVPN configuration file and certificates. These will typically be downloaded from your VPN provider's website (look for OpenVPN configuration files), and generally are zipped.
 
 PIA users - The URL to download the OpenVPN configuration files and certs is:-
 
@@ -157,9 +166,10 @@ https://www.privateinternetaccess.com/openvpn/openvpn.zip
 
 Once you have downloaded the zip (normally a zip as they contain multiple ovpn files) then extract it to /config/openvpn/ folder (if that folder doesn't exist then start and stop the docker container to force the creation of the folder).
 
-If there are multiple ovpn files then please delete the ones you don't want to use (normally filename follows location of the endpoint) leaving just a single ovpn file and the certificates referenced in the ovpn file (certificates will normally have a crt and/or pem extension).
+If there are multiple ovpn files then please delete the ones you don't want to use (normally filename follows the location of the endpoint) leaving just a single ovpn file and the certificates referenced in the ovpn file (certificates will normally have a crt and/or pem extension).
 
-**WireGuard**<br/>
+## **WireGuard**
+
 If you wish to use WireGuard (defined via 'VPN_CLIENT' env var value ) then due to the enhanced security and kernel integration WireGuard will require the container to be defined with privileged permissions and sysctl support, so please ensure you change the following docker options:-  <br/>
 
 from
@@ -172,23 +182,30 @@ to
     --privileged=true \
 ```
 
-PIA users - The WireGuard configuration file will be auto generated and will be stored in ```/config/wireguard/wg0.conf``` AFTER the first run, if you wish to change the endpoint you are connecting to then change the ```Endpoint``` line in the config file (default is Netherlands).
+### PIA Note
+
+PIA users - The WireGuard configuration file will be auto-generated and will be stored in ```/config/wireguard/wg0.conf``` AFTER the first run, if you wish to change the endpoint you are connecting to then change the ```Endpoint``` line in the config file (default is Netherlands).
+
+### Other Wireguard Note
 
 Other users - Please download your WireGuard configuration file from your VPN provider, start and stop the container to generate the folder ```/config/wireguard/``` and then place your WireGuard configuration file in there.
 
-**Notes**<br/>
-Due to Google and OpenDNS supporting EDNS Client Subnet it is recommended NOT to use either of these NS providers.
+## **DNS Note**
+Due to Google and OpenDNS supporting EDNS Client Subnet, it is recommended NOT to use either of these NS providers.
 The list of default NS providers in the above example(s) is as follows:-
 
 84.200.x.x = DNS Watch
 37.235.x.x = FreeDNS
 1.x.x.x = Cloudflare
 
+## PUID/PGID
 User ID (PUID) and Group ID (PGID) can be found by issuing the following command for the user you want to run the container as:-
 
 `id <username>`
 
-Due to issues with CSRF and port mapping, should you require to alter the port for the webui you need to change both sides of the -p 8080 switch AND set the WEBUI_PORT variable to the new port.
+## Note on port matching
+
+Due to issues with CSRF and port mapping, should you require to alter the port for the WebUI you need to change both sides of the -p 8080 switch AND set the WEBUI_PORT variable to the new port.
 
 For example, to set the port to 8090 you need to set -p 8090:8090 and -e WEBUI_PORT=8090
 ___


### PR DESCRIPTION
Adding a few niceties to the readme to make it a bit "easier" to read/use.

I attempted to put the provider-specific bits below the generic setup pieces.

By using markdown headers (# or ## or ###) we gain the table of contents and anchor marks to deep link into

Table of contents:

![image](https://github.com/binhex/arch-qbittorrentvpn/assets/872224/bc0518ad-1f50-4465-8eba-fb07aecfcec3)

Port forwarding change

![image](https://github.com/binhex/arch-qbittorrentvpn/assets/872224/52ef5b30-3acc-4ccd-b3d5-dff5e2e45b72)

Example layout from the top of the readme.

![image](https://github.com/binhex/arch-qbittorrentvpn/assets/872224/376592ec-b790-43c8-b918-b45f7120d428)
