### PR TITLE
Added PrivateVPN as VPN provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run -d \
     -e VPN_ENABLED=<yes|no> \
     -e VPN_USER=<vpn username> \
     -e VPN_PASS=<vpn password> \
-    -e VPN_PROV=<pia|airvpn|protonvpn|custom> \
+    -e VPN_PROV=<pia|airvpn|protonvpn|privatevpn|custom> \
     -e VPN_CLIENT=<openvpn|wireguard> \
     -e VPN_OPTIONS=<additional openvpn cli options> \
     -e ENABLE_STARTUP_SCRIPTS=<yes|no> \

--- a/run/nobody/qbittorrent.sh
+++ b/run/nobody/qbittorrent.sh
@@ -44,7 +44,7 @@ function configure_incoming_port(){
 
 	# change incoming port using the qbittorrent api - note this requires anonymous authentication via webui
 	# option 'Bypass authentication for clients on localhost'
-	if [[ "${VPN_PROV}" == "pia" ||  "${VPN_PROV}" == "protonvpn" ]] && [[ -n "${VPN_INCOMING_PORT}" ]]; then
+	if [[ "${VPN_PROV}" == "pia" ||  "${VPN_PROV}" == "protonvpn" || "${VPN_PROV}" == "privatevpn" ]] && [[ -n "${VPN_INCOMING_PORT}" ]]; then
 
 		# identify protocol, used by curl to connect to api
 		if grep -q 'WebUI\\HTTPS\\Enabled=true' "${qbittorrent_config}"; then

--- a/run/nobody/watchdog.sh
+++ b/run/nobody/watchdog.sh
@@ -106,7 +106,7 @@ while true; do
 
 			fi
 
-			if [[ "${VPN_PROV}" == "pia" || "${VPN_PROV}" == "protonvpn" ]]; then
+			if [[ "${VPN_PROV}" == "pia" || "${VPN_PROV}" == "protonvpn" || "${VPN_PROV}" == "privatevpn" ]]; then
 
 				# if vpn port is not an integer then dont change port
 				if [[ ! "${VPN_INCOMING_PORT}" =~ ^-?[0-9]+$ ]]; then
@@ -215,7 +215,7 @@ while true; do
 
 	if [[ "${DEBUG}" == "true" && "${VPN_ENABLED}" == "yes" ]]; then
 
-		if [[ "${VPN_PROV}" == "pia" || "${VPN_PROV}" == "protonvpn" ]] && [[ -n "${VPN_INCOMING_PORT}" ]]; then
+		if [[ "${VPN_PROV}" == "pia" || "${VPN_PROV}" == "protonvpn" || "${VPN_PROV}" == "privatevpn" ]] && [[ -n "${VPN_INCOMING_PORT}" ]]; then
 
 			echo "[debug] VPN incoming port is ${VPN_INCOMING_PORT}"
 			echo "[debug] qBittorrent incoming port is ${qbittorrent_port}"


### PR DESCRIPTION
Added support for [PrivateVPN](https://privatevpn.com/) as VPN provider. 
Depending on VPN server and profile, when using OpenVPN one or all ports will be forwarded. 
Note: When using Wireguard, port forwarding is not supported.